### PR TITLE
Switch over to using CLI install script.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
-	"onCreateCommand": "dotnet new install Aspire.ProjectTemplates::9.3.1 --force",
+	"onCreateCommand": "curl -sSL https://aspire.dev/install.sh | bash",
 	"postStartCommand": "dotnet dev-certs https --trust",
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
Instead of installing project templates and expecting people to do `dotnet new` - we now have the CLI experience.