### PR TITLE
Fix Codespaces prebuild failure due to Yarn GPG key expiration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble
+
+# Fix Yarn GPG key issue - remove the problematic Yarn repository
+# that has an expired/rotated signing key causing apt-get update to fail
+# See: https://github.com/devcontainers/images/issues/1752
+RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
 {
 	"name": "Aspire",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/powershell:1": {},


### PR DESCRIPTION
## Problem

The Codespaces prebuild CI will fail on the next run with:
```
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install!
```

The last successful prebuild was on December 10, 2025 — before the Yarn GPG key expired in January 2026.

## Root Cause

The base image `mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble` includes a Yarn apt repository with an expired/rotated GPG key (`NO_PUBKEY 62D54FD4003F6525`). When the Docker-in-Docker feature runs `apt-get update`, the invalid signature causes the entire build to fail.

## Why We Need Our Own Dockerfile

1. **We don't use Yarn** - This devcontainer is for .NET Aspire development. Node.js is provided via the `ghcr.io/devcontainers/features/node:1` feature which includes npm. Yarn is not needed.

2. **Yarn v1 is no longer actively developed** - Per the Yarn maintainers: "Development of Yarn v1 is finished now (no new work is planned)." The GPG key was extended to 2030, but there's discussion about removing the apt repository from base images entirely.

3. **This has happened before** - The Yarn GPG key expiration issue previously occurred in 2023 (devcontainers/images#370). Using a Dockerfile to remove the unused repository protects us from future key rotations.

4. **No ETA on upstream fix** - The issue is tracked at https://github.com/devcontainers/images/issues/1752 (opened Jan 23, 2026). While maintainers have patched some images, the `dotnet:dev-10.0-noble` image hasn't been rebuilt yet. There's no committed timeline for when all images will be updated.

5. **The fix runs too late otherwise** - Using `onCreateCommand` to remove the repository doesn't work because devcontainer features (like Docker-in-Docker) are installed before `onCreateCommand` runs. A Dockerfile is the only way to fix apt before feature installation.

## Changes

- Added `.devcontainer/Dockerfile` that removes `/etc/apt/sources.list.d/yarn.list`
- Updated `.devcontainer/devcontainer.json` to use the Dockerfile instead of direct image reference

## References

- Upstream issue: https://github.com/devcontainers/images/issues/1752
- Yarn GPG key issue: https://github.com/yarnpkg/yarn/issues/9216
- Previous occurrence: https://github.com/devcontainers/images/issues/370
- Same fix applied to aspire-devcontainer-nightly: https://github.com/dotnet/aspire-devcontainer-nightly/pull/6