### PR TITLE
Update VSCode extensions in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,8 +34,7 @@
 		"vscode": {
 			"extensions": [
 				"ms-dotnettools.csdevkit",
-				"GitHub.copilot-chat",
-				"GitHub.copilot"
+				"github.copilot-chat"
 			]
 		}
 	}


### PR DESCRIPTION
- remove `github.copilot` 
    - This extension is deprecated. Use the GitHub Copilot Chat extension instead.
- align extension identifier to Marketplace  
  <img width="391" height="339" alt="image" src="https://github.com/user-attachments/assets/1c3ebbf2-94b4-4b96-9385-dd97fa9ec55e" />
